### PR TITLE
Fix for Failed to find data adapter error

### DIFF
--- a/time_series_generator/time_series_generator.py
+++ b/time_series_generator/time_series_generator.py
@@ -1,8 +1,9 @@
 import numpy as np
 import json
 import sys
+from keras.utils import data_utils
 
-class TimeseriesGenerator(object):
+class TimeseriesGenerator(data_utils.Sequence):
     """Utility class for generating batches of temporal data.
 
     This class takes in a sequence of data-points gathered at


### PR DESCRIPTION
When attempting to run **model.fit** or **model.fit_generator** such as this -

`model.fit_generator(generator,epochs=10)`

Following error is thrown -

> ValueError: Failed to find data adapter that can handle input: <class 'time_series_generator.time_series_generator.TimeseriesGenerator'>, <class 'NoneType'>

Fixed by changing **time_series_generator.py**. Added the line -

`from keras.utils import data_utils`

and modifying the line -

`class TimeseriesGenerator(object):`
to
`class TimeseriesGenerator(data_utils.Sequence):`

Packages used in testing -
Keras - 2.9.0
Sklearn - 1.0.2
Tensorflow - 2.9.2
Numpy -1.21.6
Pandas - 1.3.5

Co-Authored-By: Kejid <36007786+kejid@users.noreply.github.com>